### PR TITLE
Add serilization flag for handling requests

### DIFF
--- a/src/offchainapi/networking.py
+++ b/src/offchainapi/networking.py
@@ -92,7 +92,12 @@ class VASPOffChainApi(MethodView):
 
         # Process the request and send a response back.
         try:
-            response = channel.parse_handle_request(request_json)
+            if request.headers.get('status') == 'encoded':
+                response = channel.parse_handle_request(
+                    request_json, encoded=True
+                )
+            else:
+                response = channel.parse_handle_request(request_json)
         except TypeError:
             # This exception is triggered when the channel cannot load the
             # json request; eg. when the clients sends a json dict instead of

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -254,11 +254,11 @@ class VASPPairChannel:
                 self.send_request(request)
 
 
-    def parse_handle_request(self, json_command):
+    def parse_handle_request(self, json_command, encoded=False):
         ''' Handles a request provided as a json_string '''
         with self.rlock:
             try:
-                req_dict = json.loads(json_command)
+                req_dict = json.loads(json_command) if encoded else json_command
                 request = CommandRequestObject.from_json_data_dict(req_dict, JSONFlag.NET)
                 return self.handle_request(request)
             except JSONParsingError:

--- a/src/offchainapi/tests/test_networking.py
+++ b/src/offchainapi/tests/test_networking.py
@@ -5,6 +5,7 @@ from ..protocol_messages import CommandRequestObject
 from ..utils import JSONFlag
 from ..payment_logic import Status
 
+from flask import request
 from json import dumps, loads
 from unittest.mock import MagicMock
 import pytest
@@ -97,7 +98,7 @@ def bad_request_json():
 
 def test_process_request(server, flask_client, url, request_json):
     server.vasp.info_context.is_authorised_VASP.return_value = True
-    response = flask_client.post(url, json=dumps(request_json))
+    response = flask_client.post(url, json=request_json)
     assert response.status_code == 200
     assert loads(response.data)['status'] == 'success'
 
@@ -110,5 +111,7 @@ def test_process_request_bad_vasp(server, flask_client, url, request_json):
 
 def test_process_request_bad_request(server, flask_client, url, bad_request_json):
     server.vasp.info_context.is_authorised_VASP.return_value = True
-    response = flask_client.post(url, json=bad_request_json)
+    response = flask_client.post(
+        url, json=bad_request_json, headers={'status': 'encoded'}
+    )
     assert response.status_code == 400

--- a/src/offchainapi/tests/test_sample_service.py
+++ b/src/offchainapi/tests/test_sample_service.py
@@ -105,7 +105,7 @@ def simple_response_json_error(request):
     resp.command_seq = cmd_seq
     if status == 'failure':
         resp.error = OffChainError(protoerr, errcode)
-    json_obj = json.dumps(resp.get_json_data_dict(JSONFlag.NET))
+    json_obj = resp.get_json_data_dict(JSONFlag.NET)
     return json_obj
 
 
@@ -119,7 +119,7 @@ def simple_request_json(payment_action, my_addr, other_addr):
     command = PaymentCommand(payment)
     request = CommandRequestObject(command)
     request.seq = 0
-    return json.dumps(request.get_json_data_dict(JSONFlag.NET))
+    return request.get_json_data_dict(JSONFlag.NET)
 
 
 def test_business_simple(my_addr):


### PR DESCRIPTION
Simple serialization flat telling `protocol.py` when to load the request.