### PR TITLE
Facilities to sign and verify recipient signatures

### DIFF
--- a/src/offchainapi/crypto.py
+++ b/src/offchainapi/crypto.py
@@ -12,6 +12,11 @@ class OffChainInvalidSignature(Exception):
     pass
 
 
+class IncorrectInputException(Exception):
+    pass
+
+
+
 class ComplianceKey:
 
     def __init__(self, key):
@@ -79,7 +84,7 @@ class ComplianceKey:
             verifier.verify(self._key, alg='EdDSA')
             return verifier.payload.decode("utf-8")
         except jws.InvalidJWSSignature:
-            raise OffChainInvalidSignature()
+            raise OffChainInvalidSignature(signature)
 
     def thumbprint(self):
         return self._key.thumbprint()
@@ -115,11 +120,11 @@ class ComplianceKey:
         try:
             pub.verify(bytes.fromhex(signature), msg_b)
         except InvalidSignature:
-            raise OffChainInvalidSignature()
+            raise OffChainInvalidSignature(reference_id_bytes, libra_address_bytes, value_u64, signature)
 
 def encode_ref_id_data(reference_id_bytes, libra_address_bytes, value_u64):
     if len(libra_address_bytes) != 16:
-        raise Exception('Libra Address raw format is 16 bytes.')
+        raise IncorrectInputException('Libra Address raw format is 16 bytes.')
 
     message = b''
     message += reference_id_bytes

--- a/src/offchainapi/tests/test_crypto.py
+++ b/src/offchainapi/tests/test_crypto.py
@@ -92,7 +92,7 @@ def test_sign_verif_incorrect():
         assert key2.verify_message(sig) == 'Hello World!'
 
 
-def test_encode_receipient():
+def test_encode_recipient():
 
     META_DATA_BYTES = [0x61, 0x1e, 0x0,  0x0,  0x0, 0x0,  0x0, 0x0]
     LIBRA_ADDRESS = [


### PR DESCRIPTION
According to the spec the recipient signs a tuple of (reference_id, libra_address, value) using the compliance key for transactions above a certain value. This PR provides a first implementation. 