### PR TITLE
Add better documentation for error codes

### DIFF
--- a/src/offchainapi/errors.py
+++ b/src/offchainapi/errors.py
@@ -14,26 +14,30 @@ class OffChainErrorCode(Enum):
 
 
     # Indicates that a request with the same cid has already been received,
-    # but the command is different. As a reult the command will not
+    # but the command is different. As a reult the command will not be
     # considered further, and a protocol error with this code is returned.
     conflict = 'conflict'
 
     # Indicates that some other command has a lock on one or more dependencies
     # necessary for this command to commit. As a result the command should be
-    # sent again in a while, once the other command status has been resolved.
+    # resent again in a while, once the other command status has been resolved.
     # The command is discarded, with a protocol error, and should be
     # resubmitted later.
     wait = 'wait'
 
-    # Indicates that a parsing error has occured. The request is therefore
-    # discarded with a protocol error.
+    # Indicates that a parsing error has occured at the level of the JSON parser.
+    # The request is therefore discarded with a protocol error, since we may not
+    # be able to recover a cid.
     parsing_error = 'parsing_error'
 
-    # Indicates that the signature verification failed
+    # Indicates that the signature verification failed, and therefore the
+    # command is discarded as it may not be originating from the legitimate
+    # other VASP.
     invalid_signature = 'invalid_signature'
 
     # One of the dependencies is missing -- this is recoverable if it becomes
-    # available down the line. Whence it is a protocol error only.
+    # available down the line. Whence it is a protocol error only; the command
+    # is ignored and can be re-sent later if the dependency becomes available.
     missing_dependencies = 'missing_dependencies'
 
     # Codes for command errors
@@ -43,11 +47,10 @@ class OffChainErrorCode(Enum):
     # and the command with the same cid will always fail with the same error.
     # Therefore a new request)
 
-    # Indicates that one or more dependencies are missing, or have already been
-    # used by another command. As a result committing this command may result in
-    # a conflict / inconsistent state. The command is therefore permanently
-    # rejected with an idempotent command error.
-
+    # Indicates that one or more dependencies have already been used by another
+    # command. As a result committing this command would result in
+    # a conflict / inconsistent state. The command is therefore recorded as
+    # permanently rejected with an idempotent command error.
     used_dependencies    = 'used_dependencies'
 
 
@@ -58,19 +61,58 @@ class OffChainErrorCode(Enum):
     # as all command errors, results in the request with this cid to alreays
     # fail.)
 
+
+    # Indicates that the libra subaddress in the payment (either sender or
+    # receiver) could not be parsed as a Libra Address. Used when checking
+    # all commands creating or updating payments.
     payment_invalid_libra_address = 'payment_invalid_libra_address'
+
+    # Indicates that the subaddress component of the libra payment (either
+    # sender or receiver) is empty, which is invalid. Checked for all commands
+    # updating a payment.
     payment_invalid_libra_subaddress = 'payment_invalid_libra_subaddress'
+
+    # Indicates that either the initial set of sender and receiver status,
+    # or a status transition updating these as part of a command are invalid.
+    # This is checked for every command creating or updating a payment.
     payment_wrong_status = 'payment_wrong_status'
+
+    # Indicates that a command updating a payment modifies the actor (sender
+    # or receiver) representing the other VASP. After the initial payment
+    # definition each VASP may only update the payment actor representing itself.
+    # Checked for all commands updating a payment.
     payment_changed_other_actor = 'payment_changed_other_actor'
+
+    # Indicates that the command creates or updates a payment involving VASPs
+    # that are different from the VASPs at either ends of the channel on which
+    # it was sent.
     payment_wrong_actor = 'payment_wrong_actor'
+
+    # Indicates that the _reads or _writes fields are wrong. They may have
+    # two wrong number of elements, or not refer to the same object by reference ID.
+    # Or that the reference ID format of the payment has an incorrect format, or
+    # is updated by a command.
     payment_wrong_structure = 'payment_wrong_structure'
-    payment_dependency_error = 'payment_dependency_error'
+
+    # In dicates that an invalid recipient compliance signature
+    # on the payment reference ID was included in the payment. Checked
+    # for all payment command updates .
     payment_wrong_recipient_signature = 'payment_wrong_recipient_signature'
 
-    ## Abort codes
-    payment_insufficient_funds = 'payment_insufficient_funds'
-    payment_vasp_error = 'payment_vasp_error'
 
+    ## Abort codes
+
+    # These error codes may be used by VASP business logic to indicate reasons
+    # for aborting a payment.
+
+    # Indicates and abort occured due to insufficient funds in the
+    # sender account.
+    payment_insufficient_funds = 'payment_insufficient_funds'
+
+    # General opaque error indicating that something went wrong in the VASP
+    # as part of processing a payment, and an error was logged locally (but
+    # not communicated to the other VASP.)
+    payment_vasp_error = 'payment_vasp_error'
 
     # Test codes
     test_error_code = 'test_error_code'

--- a/src/offchainapi/payment_command.py
+++ b/src/offchainapi/payment_command.py
@@ -68,7 +68,7 @@ class PaymentCommand(ProtocolCommand):
         new_version = self.get_new_version_number()
         if new_version != version_number:
             raise PaymentLogicError(
-                OffChainErrorCode.payment_dependency_error,
+                OffChainErrorCode.payment_wrong_structure,
                 f"Unknown object {version_number} (only know {new_version})"
             )
 
@@ -83,7 +83,7 @@ class PaymentCommand(ProtocolCommand):
             _, dep = self.reads_version_map[0]
             if dep not in dependencies:
                 raise PaymentLogicError(
-                    OffChainErrorCode.payment_dependency_error,
+                    OffChainErrorCode.payment_wrong_structure,
                     f'Could not find payment dependency: {dep}'
                 )
             dep_object = dependencies[dep]

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -511,7 +511,7 @@ class VASPPairChannel:
         if any(dv not in obj_locks for dv in depends_on_version):
             # Some dependencies are missing but may becomes available later?
             response = make_protocol_error(
-                request, code=OffChainErrorCode.wait)
+                request, code=OffChainErrorCode.missing_dependencies)
             return response
 
         # Check all dependencies are here and not used.


### PR DESCRIPTION
## Motivation

The `errors.py` module contains all errors that can be returned by a VASP, but had no documentation. No we have added documentation to help implementors make sense of each of these errors.

Also:
* Rationalized payment structure errors into `payment_wrong_structure` errors.
* When dependencies are missing now we send the more specific `missing_dependencies` error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

The changes involve largely docs and the tests (tox) pass.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
