### PR TITLE
Refactored the libra address to take a configurable default HRP

### DIFF
--- a/src/offchainapi/libra_address.py
+++ b/src/offchainapi/libra_address.py
@@ -11,6 +11,20 @@ from .bech32 import (
     LIBRA_ZERO_SUBADDRESS,
 )
 
+# Set a global Human Readable Part.
+global GLOBAL_HRP
+GLOBAL_HRP = LBR
+
+def set_global_hrp(hrp = None):
+    """
+    Sets the global human readable part of the address, used by default constructors
+    to a specific string. If 'hrp' is None or ommitted resets the hrp to the detault LBR.
+    """
+    global GLOBAL_HRP
+    if hrp is None:
+        GLOBAL_HRP = LBR
+    else:
+        GLOBAL_HRP = hrp
 
 class LibraAddressError(Exception):
     ''' Represents an error when creating a LibraAddress. '''
@@ -28,10 +42,16 @@ class LibraAddress:
     """
 
     @classmethod
-    def from_bytes(cls, onchain_address_bytes, subaddress_bytes=None, hrp=LBR):
+    def from_bytes(cls, onchain_address_bytes, subaddress_bytes=None, hrp=None):
         """ Return a LibraAddress given onchain address in bytes, subaddress
-        in bytes (optional), and hrp (Human Readable Part)
+        in bytes (optional), and hrp (Human Readable Part). If hrp is not given,
+        use the global hrp.
         """
+
+        if hrp is None:
+            global GLOBAL_HRP
+            hrp = GLOBAL_HRP
+
         try:
             encoded_address = bech32_address_encode(
                 hrp,
@@ -48,10 +68,16 @@ class LibraAddress:
         return cls(encoded_address, onchain_address_bytes, subaddress_bytes, hrp)
 
     @classmethod
-    def from_hex(cls, onchain_address_hex, subaddress_hex=None, hrp=LBR):
+    def from_hex(cls, onchain_address_hex, subaddress_hex=None, hrp=None):
         """ Return a LibraAddress given onchain address in hex, subaddress
-        in hex (optional), and hrp (Human Readable Part)
+        in hex (optional), and hrp (Human Readable Part). If hrp is not given,
+        use the global hrp.
         """
+
+        if hrp is None:
+            global GLOBAL_HRP
+            hrp = GLOBAL_HRP
+
         onchain_address_bytes = bytes.fromhex(onchain_address_hex)
         subaddress_bytes = bytes.fromhex(subaddress_hex) if subaddress_hex else None
         return cls.from_bytes(onchain_address_bytes, subaddress_bytes, hrp)

--- a/src/offchainapi/tests/test_libra_address.py
+++ b/src/offchainapi/tests/test_libra_address.py
@@ -5,7 +5,7 @@ import pytest
 from uuid import uuid4
 
 from ..bech32 import Bech32Error, bech32_address_encode, LBR, TLB
-from ..libra_address import LibraAddress, LibraAddressError
+from ..libra_address import LibraAddress, LibraAddressError, GLOBAL_HRP, set_global_hrp
 
 
 def test_onchain_address_only_OK():
@@ -68,6 +68,22 @@ def test_from_bytes():
     libra_addr = LibraAddress.from_hex(onchain_address_hex, None)
     assert libra_addr.onchain_address_bytes == bytes.fromhex(onchain_address_hex)
     assert libra_addr.subaddress_bytes == None
+
+def test_from_global_hrp():
+    onchain_address_bytes = uuid4().bytes
+    subaddress_bytes = uuid4().bytes[8:]
+    libra_addr_one = LibraAddress.from_bytes(onchain_address_bytes, subaddress_bytes)
+    assert libra_addr_one.as_str()[:3] == GLOBAL_HRP
+
+    # Now change the global HRP
+    set_global_hrp(hrp = 'tlb')
+    libra_addr_two = LibraAddress.from_bytes(onchain_address_bytes, subaddress_bytes)
+    assert libra_addr_two.as_str()[:3] == 'tlb'
+
+    # Now reset it back to LBR
+    set_global_hrp()
+    libra_addr_three = LibraAddress.from_bytes(onchain_address_bytes, subaddress_bytes)
+    assert libra_addr_three.as_str()[:3] == 'lbr'
 
 
 def test_from_encoded_str():


### PR DESCRIPTION
## Motivation

Constructors for LibraAddress defaulted to a 'lbr' human readable part (HRP) default making it hard to debug omission errors involving different HRPs. Now we instead allow users of the LibraAddress library to set a default HRP using `set_global_hrp`, that is then used as the default when no other hrp is specified.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

YES.

## Test Plan

Added a test for the behavior above in pytest / tox.